### PR TITLE
fix(tests): replace hardcoded API URL with EXPO_PUBLIC_API_URL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env.development and fill in your values
+EXPO_PUBLIC_API_URL=http://localhost:5155

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ yarn-error.*
 
 # local env files
 .env*.local
+.env.development
+.env.production
 
 # typescript
 *.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,8 +313,7 @@ AppNavigator (checks auth status)
 - TypeScript configured with strict mode
 - Expo supports iOS, Android, and web platforms
 - Edge-to-edge display enabled for Android
-- API base URL switches based on `__DEV__` flag
-- Development API: `http://{expo-host}:5155`
+- API base URL read from `EXPO_PUBLIC_API_URL` environment variable (see Environment Configuration below)
 
 ## Architecture Patterns (Based on Bulletproof React)
 
@@ -553,6 +552,8 @@ Backend includes DatabaseSeeder with test data:
 - JWT signing key (32+ characters)
 - PostgreSQL credentials
 
-**Mobile:** API base URL in `/src/lib/constants.ts`
-- Development: `http://{expo-host}:5155`
-- Production: Hard-coded (needs update for deployment)
+**Mobile:** Uses `EXPO_PUBLIC_*` environment variables (Expo SDK 49+ native support)
+- Copy `.env.example` to `.env.development` and set `EXPO_PUBLIC_API_URL` to your local or ngrok URL
+- `.env.development` and `.env.production` are gitignored — never committed
+- `src/lib/config.ts` exports `API_BASE_URL` and throws at startup if the variable is missing
+- Tests set `EXPO_PUBLIC_API_URL=http://localhost:5155` via `jest.config.js` (no `.env` file needed for tests)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+process.env.EXPO_PUBLIC_API_URL = 'http://localhost:5155';
+
 module.exports = {
   testEnvironment: 'node',
   preset: 'react-native',

--- a/src/__tests__/handlers/authHandlers.ts
+++ b/src/__tests__/handlers/authHandlers.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw';
 
-const API_BASE_URL = 'http://localhost:5155';
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL!;
 
 export const authHandlers = [
   // Login

--- a/src/__tests__/handlers/booksHandlers.ts
+++ b/src/__tests__/handlers/booksHandlers.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw';
 
-const API_BASE_URL = 'http://localhost:5155';
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL!;
 
 const mockBook = {
   id: 1,

--- a/src/__tests__/handlers/communitiesHandlers.ts
+++ b/src/__tests__/handlers/communitiesHandlers.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw';
 
-const API_BASE_URL = 'http://localhost:5155';
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL!;
 
 const mockCommunity = {
   id: 1,

--- a/src/__tests__/handlers/notificationsHandlers.ts
+++ b/src/__tests__/handlers/notificationsHandlers.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw';
 
-const API_BASE_URL = 'http://localhost:5155';
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL!;
 
 const mockNotification = {
   id: 1,

--- a/src/__tests__/handlers/sharesHandlers.ts
+++ b/src/__tests__/handlers/sharesHandlers.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw';
 import { ShareStatus } from '../../lib/constants';
 
-const API_BASE_URL = 'http://localhost:5155';
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL!;
 
 const mockShare = {
   id: 1,

--- a/src/__tests__/handlers/userBooksHandlers.ts
+++ b/src/__tests__/handlers/userBooksHandlers.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw';
 
-const API_BASE_URL = 'http://localhost:5155';
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL!;
 
 const mockUserBook = {
   id: 1,

--- a/src/features/library/api/coverAnalysisApi.ts
+++ b/src/features/library/api/coverAnalysisApi.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from '../../../lib/constants';
+import { API_BASE_URL } from '../../../lib/config';
 import * as SecureStore from 'expo-secure-store';
 import { CoverAnalysisResponse } from '../types/coverAnalysis';
 import { ANALYSIS_TIMEOUT_MS } from '../utils/imageProcessingConfig';

--- a/src/features/shares/services/signalRService.ts
+++ b/src/features/shares/services/signalRService.ts
@@ -5,7 +5,7 @@ import {
   LogLevel
 } from '@microsoft/signalr';
 import * as SecureStore from 'expo-secure-store';
-import { API_BASE_URL } from '../../../lib/constants';
+import { API_BASE_URL } from '../../../lib/config';
 import { ChatMessage, ConnectionStatus } from '../types/chat';
 
 class SignalRService {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
-import { API_BASE_URL } from './constants';
 import * as SecureStore from 'expo-secure-store';
+import { API_BASE_URL } from './config';
 
 export class ApiError extends Error {
   constructor(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,9 @@
+const apiUrl = process.env.EXPO_PUBLIC_API_URL;
+
+if (!apiUrl) {
+  throw new Error(
+    'EXPO_PUBLIC_API_URL is not set. Copy .env.example to .env.development and set your API URL.'
+  );
+}
+
+export const API_BASE_URL = apiUrl;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,16 +1,3 @@
-import Constants from "expo-constants";
-
-//local
-//const devServerUri = 'http://' + Constants.expoConfig?.hostUri?.split(':').shift() + ':5155';
-
-//container
-//const devServerUri = 'http://' + Constants.expoConfig?.hostUri?.split(':').shift() + ':3001';
-
-//ngrok
- const devServerUri = 'https://unproctored-nonirrationally-golda.ngrok-free.dev';
-
-export const API_BASE_URL = __DEV__ ? devServerUri : 'http://192.168.1.72:5155'; //todo replace with prod api url
-
 export enum BookStatus {
   Available = 1,
   BeingShared = 2,

--- a/src/utils/__tests__/imageUtils.test.ts
+++ b/src/utils/__tests__/imageUtils.test.ts
@@ -1,6 +1,7 @@
 import { getFullImageUrl, getImageUrlFromId, cropImageToScanArea } from '../imageUtils';
-import { API_BASE_URL } from '../../lib/constants';
 import * as ImageManipulator from 'expo-image-manipulator';
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL!;
 
 // Mock expo-image-manipulator
 jest.mock('expo-image-manipulator', () => ({
@@ -15,25 +16,6 @@ jest.mock('expo-image-manipulator', () => ({
 jest.mock('../../features/library/utils/imageProcessingConfig', () => ({
   RESIZE_WIDTH: 1920,
   COMPRESSION_QUALITY: 0.8,
-}));
-
-// Mock the API_BASE_URL constant
-jest.mock('../../lib/constants', () => ({
-  API_BASE_URL: 'http://localhost:5155',
-  BookStatus: {
-    Available: 1,
-    BeingShared: 2,
-    Unavailable: 3,
-  },
-  ShareStatus: {
-    Requested: 1,
-    Ready: 2,
-    PickedUp: 3,
-    Returned: 4,
-    HomeSafe: 5,
-    Disputed: 6,
-    Declined: 7,
-  },
 }));
 
 describe('imageUtils', () => {

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -1,5 +1,5 @@
-import { API_BASE_URL } from '../lib/constants';
 import * as ImageManipulator from 'expo-image-manipulator';
+import { API_BASE_URL } from '../lib/config';
 import {
   RESIZE_WIDTH,
   COMPRESSION_QUALITY,


### PR DESCRIPTION
## Summary
- Fixes 41 failing tests caused by MSW handler URL mismatch (handlers used `localhost:5155`, app was configured with a ngrok URL)
- Moves API base URL out of source code into `EXPO_PUBLIC_API_URL` environment variable using Expo's native env var support
- Adds `src/lib/config.ts` as single source of truth for `API_BASE_URL`, throws at startup with a clear message if the var is missing

## Test plan
- [ ] All 104 tests pass (`npm test`)
- [ ] App runs normally with `.env.development` containing your API URL
- [ ] Missing env var throws a clear error at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)