### PR TITLE
fix(communities): prevent crash when navigating to Communities tab

### DIFF
--- a/src/features/communities/CommunitiesScreen.tsx
+++ b/src/features/communities/CommunitiesScreen.tsx
@@ -152,12 +152,14 @@ export default function CommunitiesScreen() {
         />
       )}
 
-      <QRCodeModal
-        visible={selectedCommunityForQR !== null}
-        onClose={() => setSelectedCommunityForQR(null)}
-        communityId={selectedCommunityForQR?.id || 0}
-        communityName={selectedCommunityForQR?.name || ''}
-      />
+      {selectedCommunityForQR && (
+        <QRCodeModal
+          visible={true}
+          onClose={() => setSelectedCommunityForQR(null)}
+          communityId={selectedCommunityForQR.id}
+          communityName={selectedCommunityForQR.name}
+        />
+      )}
     </View>
   );
 }

--- a/src/features/communities/components/QRCodeModal.tsx
+++ b/src/features/communities/components/QRCodeModal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useMemo } from 'react';
 import {
   Modal,
   View,
@@ -30,7 +30,14 @@ export function QRCodeModal({
   const qrViewRef = useRef<View>(null);
   const [isSharing, setIsSharing] = useState(false);
 
-  const qrData = generateQRCodeData(communityId);
+  const qrData = useMemo(
+    () => (Number.isInteger(communityId) && communityId > 0 ? generateQRCodeData(communityId) : null),
+    [communityId]
+  );
+
+  if (!qrData) {
+    return null;
+  }
 
   const handleShare = async () => {
     try {


### PR DESCRIPTION
## Summary
- `QRCodeModal` was always mounted with `communityId=0` as a fallback, causing `generateQRCodeData` to throw `Invalid community ID: 0` on every render when no community was selected
- Fixed by conditionally rendering `QRCodeModal` only when a community is selected (`selectedCommunityForQR && ...`)
- Added `useMemo` in `QRCodeModal` to avoid recomputing QR data on every render
- Added a guard in `QRCodeModal` to return `null` if an invalid `communityId` is ever passed

## Test plan
- [ ] Navigate to the Communities tab — should load without errors
- [ ] Tap the QR code icon on a community — modal should open and display the QR code
- [ ] Close the modal — should dismiss cleanly
- [ ] Tap QR icon again on a different community — should show correct QR for that community

🤖 Generated with [Claude Code](https://claude.com/claude-code)