### PR TITLE
Remove user book status

### DIFF
--- a/src/__tests__/handlers/userBooksHandlers.ts
+++ b/src/__tests__/handlers/userBooksHandlers.ts
@@ -6,7 +6,6 @@ const mockUserBook = {
   id: 1,
   userId: 'user-1',
   bookId: 1,
-  status: 1, // Available
   book: {
     id: 1,
     title: 'The Great Gatsby',
@@ -48,14 +47,6 @@ export const userBooksHandlers = [
   // Get user's books
   http.get(`${API_BASE_URL}/user-books/user/:userId`, () => {
     return HttpResponse.json([mockUserBook]);
-  }),
-
-  // Update user book status
-  http.put(`${API_BASE_URL}/user-books/:id/status`, async ({ params }) => {
-    return HttpResponse.json({
-      ...mockUserBook,
-      id: Number(params.id),
-    });
   }),
 
   // Delete user book - handles confirmation flow

--- a/src/__tests__/utils/factories.ts
+++ b/src/__tests__/utils/factories.ts
@@ -1,7 +1,7 @@
 import { User } from '../../types/auth';
 import { Share } from '../../features/shares/types';
 import { Book } from '../../features/books/types';
-import { ShareStatus, BookStatus } from '../../lib/constants';
+import { ShareStatus } from '../../lib/constants';
 
 let userIdCounter = 1;
 let shareIdCounter = 1;
@@ -49,7 +49,6 @@ export const createMockShare = (overrides?: Partial<Share>): Share => {
       id: userBookIdCounter,
       userId: lender.id,
       bookId: book.id,
-      status: BookStatus.BeingShared,
       isDeleted: false,
       book,
       user: lender,

--- a/src/components/BookCardStyles.ts
+++ b/src/components/BookCardStyles.ts
@@ -116,30 +116,6 @@ export const bookCardStyles = StyleSheet.create({
     marginHorizontal: 16,
     marginBottom: 16,
   },
-  statusContainer: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 4,
-    alignSelf: 'flex-start',
-    marginBottom: 8,
-  },
-  statusAvailable: {
-    backgroundColor: '#4CAF50',
-  },
-  statusBeingShared: {
-    backgroundColor: '#D4A574',
-  },
-  statusUnavailable: {
-    backgroundColor: '#C4443C',
-  },
-  statusText: {
-    color: '#FEFCF9',
-    fontSize: 14,
-    fontWeight: '500',
-    textAlign: 'center',
-    width: 100
-  },
-  
   // Legacy styles for backward compatibility - will be removed after components are updated
   header: {
     padding: 16,

--- a/src/features/books/types/index.ts
+++ b/src/features/books/types/index.ts
@@ -9,7 +9,6 @@ export interface BookOwner {
   userBookId: number;
   ownerUserId: string;
   ownerFirstName: string;
-  status: number;
   communityId: number;
   communityName: string;
 }
@@ -25,7 +24,6 @@ export interface UserBook {
   id: number;
   userId: string;
   bookId: number;
-  status: number;
   book: Book;
 }
 

--- a/src/features/library/LibraryScreen.tsx
+++ b/src/features/library/LibraryScreen.tsx
@@ -26,7 +26,7 @@ type LibraryScreenRouteProp = RouteProp<LibraryStackParamList, 'LibraryMain'>;
 export default function LibraryScreen() {
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery] = useDebounceValue(searchQuery, 300);
-  const { userBooks, loading, error, updateUserBookStatus, removeUserBook } = useUserBooks();
+  const { userBooks, loading, error, removeUserBook } = useUserBooks();
   const navigation = useNavigation<LibraryScreenNavigationProp>();
   const route = useRoute<LibraryScreenRouteProp>();
 
@@ -117,19 +117,10 @@ export default function LibraryScreen() {
     }
   };
 
-  const handleStatusChange = async (userBookId: number, status: number) => {
-    try {
-      await updateUserBookStatus(userBookId, status);
-    } catch (error) {
-      console.error('Failed to update book status:', error);
-    }
-  };
-
   const renderBookCard = ({ item }: { item: UserBook }) => (
-    <LibraryBookCard 
-      userBook={item} 
+    <LibraryBookCard
+      userBook={item}
       onRemovePress={handleRemoveBook}
-      onStatusChange={handleStatusChange}
     />
   );
 

--- a/src/features/library/api/userBooksApi.ts
+++ b/src/features/library/api/userBooksApi.ts
@@ -7,10 +7,6 @@ export const userBooksApi = {
     return api.get(`/user-books/user/${userId}`);
   },
 
-  updateUserBookStatus: async (userBookId: number, status: number): Promise<UserBook> => {
-    return api.put(`/user-books/${userBookId}/status`, status);
-  },
-
   deleteUserBook: async (userBookId: number, confirmed: boolean = false): Promise<DeleteUserBookResult> => {
     try {
       await api.delete(`/user-books/${userBookId}?confirmed=${confirmed}`);

--- a/src/features/library/components/LibraryBookCard.tsx
+++ b/src/features/library/components/LibraryBookCard.tsx
@@ -1,48 +1,20 @@
 import React, { useState } from 'react';
-import { Text, View, TouchableOpacity, Image, Alert, ActionSheetIOS, Platform } from 'react-native';
+import { Text, View, TouchableOpacity, Image, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { UserBook } from '../../books/types';
-import { BookStatus } from '../../../lib/constants';
 import { bookCardStyles } from '../../../components/BookCardStyles';
 import { getFullImageUrl } from '../../../utils/imageUtils';
 
 interface LibraryBookCardProps {
   userBook: UserBook;
   onRemovePress: (userBookId: number) => void;
-  onStatusChange: (userBookId: number, status: number) => void;
 }
 
-export const LibraryBookCard: React.FC<LibraryBookCardProps> = ({ userBook, onRemovePress, onStatusChange }) => {
+export const LibraryBookCard: React.FC<LibraryBookCardProps> = ({ userBook, onRemovePress }) => {
   const [imageError, setImageError] = useState(false);
-  
+
   const { book } = userBook;
   const hasValidThumbnail = book.thumbnailUrl && book.thumbnailUrl.trim() !== '' && !imageError;
-
-  const getStatusText = (status: number) => {
-    switch (status) {
-      case BookStatus.Available:
-        return 'Available';
-      case BookStatus.BeingShared:
-        return 'Being Shared';
-      case BookStatus.Unavailable:
-        return 'Unavailable';
-      default:
-        return 'Unknown';
-    }
-  };
-
-  const getStatusStyle = (status: number) => {
-    switch (status) {
-      case BookStatus.Available:
-        return [bookCardStyles.statusContainer, bookCardStyles.statusAvailable];
-      case BookStatus.BeingShared:
-        return [bookCardStyles.statusContainer, bookCardStyles.statusBeingShared];
-      case BookStatus.Unavailable:
-        return [bookCardStyles.statusContainer, bookCardStyles.statusUnavailable];
-      default:
-        return [bookCardStyles.statusContainer, bookCardStyles.statusUnavailable];
-    }
-  };
 
   const handleRemovePress = () => {
     Alert.alert(
@@ -62,52 +34,6 @@ export const LibraryBookCard: React.FC<LibraryBookCardProps> = ({ userBook, onRe
     );
   };
 
-  const handleStatusPress = () => {
-    const statusOptions = [
-      { label: 'Available', value: BookStatus.Available },
-      { label: 'Being Shared', value: BookStatus.BeingShared },
-      { label: 'Unavailable', value: BookStatus.Unavailable },
-    ];
-
-    if (Platform.OS === 'ios') {
-      const options = ['Cancel', ...statusOptions.map(s => s.label)];
-      const cancelButtonIndex = 0;
-      
-      ActionSheetIOS.showActionSheetWithOptions(
-        {
-          options,
-          cancelButtonIndex,
-          title: 'Change Status',
-        },
-        (buttonIndex) => {
-          if (buttonIndex > 0 && buttonIndex <= statusOptions.length) {
-            const selectedStatus = statusOptions[buttonIndex - 1];
-            if (selectedStatus.value !== userBook.status) {
-              onStatusChange(userBook.id, selectedStatus.value);
-            }
-          }
-        }
-      );
-    } else {
-      // Android - use Alert with buttons
-      const buttons = statusOptions.map(option => ({
-        text: option.label,
-        onPress: () => {
-          if (option.value !== userBook.status) {
-            onStatusChange(userBook.id, option.value);
-          }
-        },
-      }));
-      
-      buttons.push({
-        text: 'Cancel',
-        onPress: () => {}, // Do nothing on cancel
-      });
-
-      Alert.alert('Change Status', 'Select a new status for this book:', buttons);
-    }
-  };
-  
   return (
     <View style={bookCardStyles.container}>
       <TouchableOpacity 
@@ -137,16 +63,6 @@ export const LibraryBookCard: React.FC<LibraryBookCardProps> = ({ userBook, onRe
           <Text style={bookCardStyles.author}>{book.author}</Text>
           <Text style={bookCardStyles.title}>{book.title}</Text>
           
-          <View style={bookCardStyles.actionButtons}>
-            <TouchableOpacity 
-              style={getStatusStyle(userBook.status)}
-              onPress={handleStatusPress}
-            >
-              <Text style={bookCardStyles.statusText}>
-                {getStatusText(userBook.status)}
-              </Text>
-            </TouchableOpacity>
-          </View>
         </View>
       </View>
     </View>

--- a/src/features/library/hooks/useUserBooks.ts
+++ b/src/features/library/hooks/useUserBooks.ts
@@ -9,7 +9,6 @@ interface UseUserBooksReturn {
   loading: boolean;
   error: string | null;
   refreshUserBooks: () => Promise<void>;
-  updateUserBookStatus: (userBookId: number, status: number) => Promise<void>;
   removeUserBook: (userBookId: number, confirmed?: boolean) => Promise<DeleteUserBookResult>;
 }
 
@@ -47,17 +46,6 @@ export const useUserBooks = (): UseUserBooksReturn => {
     }
   }, [user?.id]);
 
-  const updateUserBookStatus = useCallback(async (userBookId: number, status: number) => {
-    try {
-      await userBooksApi.updateUserBookStatus(userBookId, status);
-      await refreshUserBooks();
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to update book status';
-      setError(errorMessage);
-      throw err;
-    }
-  }, [refreshUserBooks]);
-
   const removeUserBook = useCallback(async (userBookId: number, confirmed?: boolean): Promise<DeleteUserBookResult> => {
     try {
       const result = await userBooksApi.deleteUserBook(userBookId, confirmed);
@@ -83,7 +71,6 @@ export const useUserBooks = (): UseUserBooksReturn => {
     loading,
     error,
     refreshUserBooks,
-    updateUserBookStatus,
     removeUserBook,
   };
 };

--- a/src/features/shares/types/index.ts
+++ b/src/features/shares/types/index.ts
@@ -5,7 +5,6 @@ export interface UserBookWithOwner {
   id: number;
   userId: string;
   bookId: number;
-  status: number;
   isDeleted: boolean;
   book: Book;
   user: User;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,9 +1,3 @@
-export enum BookStatus {
-  Available = 1,
-  BeingShared = 2,
-  Unavailable = 3
-}
-
 export enum ShareStatus {
   Requested = 1,
   Ready = 2,


### PR DESCRIPTION
Closes #116

Removes all references to `UserBook` status following the API change in landonvance1/book-share-api#171. Now that soft delete handles book availability, the status field and its UI are no longer needed.

## Changes
- Removed `BookStatus` enum from `constants.ts`
- Removed `status` field from `UserBook`, `BookOwner`, and `UserBookWithOwner` types
- Removed status badge, change UI, and related logic from `LibraryBookCard`
- Removed `updateUserBookStatus` from `userBooksApi` and `useUserBooks`
- Removed status styles from `BookCardStyles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)