### PR TITLE
feat(chat): add ability to report messages

### DIFF
--- a/src/features/shares/SharesStack.tsx
+++ b/src/features/shares/SharesStack.tsx
@@ -4,6 +4,7 @@ import SharesScreen from './SharesScreen';
 import ShareDetailsScreen from './ShareDetailsScreen';
 import ShareChatScreen from './ShareChatScreen';
 import ArchivedSharesScreen from './ArchivedSharesScreen';
+import ReportMessageScreen from './screens/ReportMessageScreen';
 import { Share } from './types';
 
 export type SharesStackParamList = {
@@ -11,6 +12,7 @@ export type SharesStackParamList = {
   ShareDetails: { share: Share; isArchived?: boolean };
   ShareChat: { share: Share };
   ArchivedShares: undefined;
+  ReportMessage: { shareId: number; messageId: number };
 };
 
 const Stack = createStackNavigator<SharesStackParamList>();
@@ -22,6 +24,7 @@ export const SharesStack: React.FC = () => {
       <Stack.Screen name="ShareDetails" component={ShareDetailsScreen} />
       <Stack.Screen name="ShareChat" component={ShareChatScreen} />
       <Stack.Screen name="ArchivedShares" component={ArchivedSharesScreen} />
+      <Stack.Screen name="ReportMessage" component={ReportMessageScreen} />
     </Stack.Navigator>
   );
 };

--- a/src/features/shares/api/chatApi.ts
+++ b/src/features/shares/api/chatApi.ts
@@ -3,7 +3,8 @@ import {
   ChatMessage,
   SendMessageRequest,
   ChatMessagesResponse,
-  ChatPaginationParams
+  ChatPaginationParams,
+  ReportMessageRequest,
 } from '../types/chat';
 
 export const chatApi = {
@@ -26,5 +27,13 @@ export const chatApi = {
     message: SendMessageRequest
   ): Promise<ChatMessage> => {
     return api.post(`/shares/${shareId}/chat/messages`, message);
+  },
+
+  reportMessage: async (
+    shareId: number,
+    messageId: number,
+    body: ReportMessageRequest
+  ): Promise<void> => {
+    return api.postNoContent(`/shares/${shareId}/chat/messages/${messageId}/report`, body);
   },
 };

--- a/src/features/shares/components/MessageOptionsSheet.tsx
+++ b/src/features/shares/components/MessageOptionsSheet.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+
+interface MessageOptionsSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  onReport: () => void;
+}
+
+export function MessageOptionsSheet({ visible, onClose, onReport }: MessageOptionsSheetProps) {
+  const handleReport = () => {
+    onClose();
+    onReport();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <TouchableOpacity style={styles.backdrop} activeOpacity={1} onPress={onClose} />
+      <View style={styles.sheet}>
+        <View style={styles.handle} />
+        <TouchableOpacity style={styles.option} onPress={handleReport} activeOpacity={0.7}>
+          <Text style={styles.optionTextDestructive}>Report Message</Text>
+        </TouchableOpacity>
+        <View style={styles.separator} />
+        <TouchableOpacity style={styles.option} onPress={onClose} activeOpacity={0.7}>
+          <Text style={styles.optionTextCancel}>Cancel</Text>
+        </TouchableOpacity>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+  },
+  sheet: {
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    paddingBottom: 34,
+    paddingHorizontal: 16,
+  },
+  handle: {
+    width: 36,
+    height: 4,
+    backgroundColor: '#D1D1D6',
+    borderRadius: 2,
+    alignSelf: 'center',
+    marginTop: 8,
+    marginBottom: 8,
+  },
+  separator: {
+    height: 1,
+    backgroundColor: '#e0e0e0',
+  },
+  option: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  optionTextDestructive: {
+    fontSize: 20,
+    color: '#FF3B30',
+  },
+  optionTextCancel: {
+    fontSize: 20,
+    color: '#007AFF',
+    fontWeight: '500',
+  },
+});

--- a/src/features/shares/components/ShareChat.tsx
+++ b/src/features/shares/components/ShareChat.tsx
@@ -10,11 +10,17 @@ import {
   ActivityIndicator
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import type { StackNavigationProp } from '@react-navigation/stack';
 import { chatApi } from '../api/chatApi';
 import { signalRService } from '../services/signalRService';
 import { ChatMessage, ConnectionStatus, ChatState } from '../types/chat';
 import { Share } from '../types';
 import { useAuth } from '../../../contexts/AuthContext';
+import { SharesStackParamList } from '../SharesStack';
+import { MessageOptionsSheet } from './MessageOptionsSheet';
+
+type ShareChatNavProp = StackNavigationProp<SharesStackParamList>;
 
 interface ShareChatProps {
   share: Share;
@@ -25,6 +31,8 @@ const RATE_LIMIT_WARNING_THRESHOLD = 25; // Warn at 25 messages (5 before limit)
 
 export default function ShareChat({ share }: ShareChatProps) {
   const { user } = useAuth();
+  const navigation = useNavigation<ShareChatNavProp>();
+
   const [chatState, setChatState] = useState<ChatState>({
     messages: [],
     connectionStatus: ConnectionStatus.Disconnected,
@@ -36,7 +44,18 @@ export default function ShareChat({ share }: ShareChatProps) {
   const [messageInput, setMessageInput] = useState('');
   const [isSending, setIsSending] = useState(false);
   const [recentMessageCount, setRecentMessageCount] = useState(0);
+  const [selectedMessage, setSelectedMessage] = useState<ChatMessage | null>(null);
   const flatListRef = useRef<FlatList>(null);
+
+  const handleLongPress = useCallback((item: ChatMessage) => {
+    setSelectedMessage(item);
+  }, []);
+
+  const handleReportSelected = useCallback(() => {
+    if (!selectedMessage) return;
+    navigation.navigate('ReportMessage', { shareId: share.id, messageId: selectedMessage.id });
+    setSelectedMessage(null);
+  }, [navigation, share.id, selectedMessage]);
 
   // Initialize chat when component mounts
   useEffect(() => {
@@ -234,28 +253,40 @@ export default function ShareChat({ share }: ShareChatProps) {
 
     const timeString = formatDateTime(messageDate);
 
+    const bubble = (
+      <View style={[
+        styles.messageBubble,
+        isCurrentUser ? styles.currentUserBubble : styles.otherUserBubble
+      ]}>
+        <Text style={[
+          styles.messageText,
+          isCurrentUser ? styles.currentUserText : styles.otherUserText
+        ]}>
+          {item.content}
+        </Text>
+        <Text style={[
+          styles.messageTime,
+          isCurrentUser ? styles.currentUserTime : styles.otherUserTime
+        ]}>
+          {timeString}
+        </Text>
+      </View>
+    );
+
     return (
       <View style={[
         styles.messageContainer,
         isCurrentUser ? styles.currentUserMessage : styles.otherUserMessage
       ]}>
-        <View style={[
-          styles.messageBubble,
-          isCurrentUser ? styles.currentUserBubble : styles.otherUserBubble
-        ]}>
-          <Text style={[
-            styles.messageText,
-            isCurrentUser ? styles.currentUserText : styles.otherUserText
-          ]}>
-            {item.content}
-          </Text>
-          <Text style={[
-            styles.messageTime,
-            isCurrentUser ? styles.currentUserTime : styles.otherUserTime
-          ]}>
-            {timeString}
-          </Text>
-        </View>
+        {isCurrentUser || item.isSystemMessage ? bubble : (
+          <TouchableOpacity
+            onLongPress={() => handleLongPress(item)}
+            delayLongPress={400}
+            activeOpacity={0.7}
+          >
+            {bubble}
+          </TouchableOpacity>
+        )}
       </View>
     );
   };
@@ -286,6 +317,11 @@ export default function ShareChat({ share }: ShareChatProps) {
   }
   return (
     <View style={styles.container}>
+      <MessageOptionsSheet
+        visible={selectedMessage !== null}
+        onClose={() => setSelectedMessage(null)}
+        onReport={handleReportSelected}
+      />
       <FlatList
         ref={flatListRef}
         data={chatState.messages}

--- a/src/features/shares/hooks/useReportMessage.ts
+++ b/src/features/shares/hooks/useReportMessage.ts
@@ -1,0 +1,48 @@
+import { useState, useCallback } from 'react';
+import { ApiError } from '../../../lib/api';
+import { chatApi } from '../api/chatApi';
+import { ReportMessageRequest } from '../types/chat';
+
+type ReportResult =
+  | { success: true }
+  | { success: false; alreadyReported: true }
+  | { success: false; alreadyReported: false; error: string };
+
+interface UseReportMessageReturn {
+  reportMessage: (shareId: number, messageId: number, body: ReportMessageRequest) => Promise<ReportResult>;
+  isSubmitting: boolean;
+}
+
+export const useReportMessage = (): UseReportMessageReturn => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const reportMessage = useCallback(async (
+    shareId: number,
+    messageId: number,
+    body: ReportMessageRequest
+  ): Promise<ReportResult> => {
+    setIsSubmitting(true);
+
+    try {
+      await chatApi.reportMessage(shareId, messageId, body);
+      return { success: true };
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 409) {
+          return { success: false, alreadyReported: true };
+        }
+        if (err.status === 400) {
+          return { success: false, alreadyReported: false, error: 'You cannot report your own messages.' };
+        }
+        if (err.status === 403) {
+          return { success: false, alreadyReported: false, error: "You don't have access to this chat." };
+        }
+      }
+      return { success: false, alreadyReported: false, error: 'Something went wrong. Please try again.' };
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, []);
+
+  return { reportMessage, isSubmitting };
+};

--- a/src/features/shares/screens/ReportMessageScreen.tsx
+++ b/src/features/shares/screens/ReportMessageScreen.tsx
@@ -1,0 +1,247 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+  SafeAreaView,
+  ActivityIndicator,
+} from 'react-native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import type { StackNavigationProp } from '@react-navigation/stack';
+import type { RouteProp } from '@react-navigation/native';
+import Toast from 'react-native-toast-message';
+import { SharesStackParamList } from '../SharesStack';
+import { useReportMessage } from '../hooks/useReportMessage';
+import { ReportCategory } from '../types/chat';
+
+type ReportMessageNavigationProp = StackNavigationProp<SharesStackParamList, 'ReportMessage'>;
+type ReportMessageRouteProp = RouteProp<SharesStackParamList, 'ReportMessage'>;
+
+const CATEGORIES: { value: ReportCategory; label: string }[] = [
+  { value: ReportCategory.Spam, label: 'Spam' },
+  { value: ReportCategory.Harassment, label: 'Harassment' },
+  { value: ReportCategory.InappropriateContent, label: 'Inappropriate Content' },
+  { value: ReportCategory.Other, label: 'Other' },
+];
+
+export default function ReportMessageScreen() {
+  const navigation = useNavigation<ReportMessageNavigationProp>();
+  const route = useRoute<ReportMessageRouteProp>();
+  const { shareId, messageId } = route.params;
+
+  const [selectedCategory, setSelectedCategory] = useState<ReportCategory | null>(null);
+  const [notes, setNotes] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const { reportMessage, isSubmitting } = useReportMessage();
+
+  const handleSubmit = async () => {
+    if (!selectedCategory) return;
+    setError(null);
+
+    const result = await reportMessage(shareId, messageId, {
+      category: selectedCategory,
+      notes: notes.trim() || undefined,
+    });
+
+    if (result.success) {
+      Toast.show({ type: 'success', text1: 'Report submitted' });
+      navigation.goBack();
+    } else if (result.alreadyReported) {
+      Toast.show({ type: 'info', text1: 'Already reported', text2: 'You have already reported this message.' });
+      navigation.goBack();
+    } else {
+      setError(result.error);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backButton}>
+          <Text style={styles.backText}>Cancel</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Report Message</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      <ScrollView style={styles.content} keyboardShouldPersistTaps="handled">
+        <Text style={styles.subtitle}>
+          Let us know why you're reporting this message. Your report is anonymous.
+        </Text>
+
+        <View style={styles.categoriesSection}>
+          {CATEGORIES.map((cat) => {
+            const isSelected = selectedCategory === cat.value;
+            return (
+              <TouchableOpacity
+                key={cat.value}
+                style={[styles.categoryRow, isSelected && styles.categoryRowSelected]}
+                onPress={() => setSelectedCategory(cat.value)}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.categoryLabel, isSelected && styles.categoryLabelSelected]}>
+                  {cat.label}
+                </Text>
+                {isSelected && <Text style={styles.checkmark}>✓</Text>}
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        <Text style={styles.notesLabel}>Additional notes (optional)</Text>
+        <TextInput
+          style={styles.notesInput}
+          placeholder="Provide any additional context..."
+          value={notes}
+          onChangeText={setNotes}
+          multiline
+          maxLength={500}
+          textAlignVertical="top"
+        />
+        <Text style={styles.charCount}>{notes.length}/500</Text>
+
+        {error && <Text style={styles.errorText}>{error}</Text>}
+      </ScrollView>
+
+      <View style={styles.footer}>
+        <TouchableOpacity
+          style={[
+            styles.submitButton,
+            (!selectedCategory || isSubmitting) && styles.submitButtonDisabled,
+          ]}
+          onPress={handleSubmit}
+          disabled={!selectedCategory || isSubmitting}
+        >
+          {isSubmitting ? (
+            <ActivityIndicator size="small" color="#fff" />
+          ) : (
+            <Text style={styles.submitButtonText}>Submit Report</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#e0e0e0',
+  },
+  backButton: {
+    padding: 4,
+    width: 60,
+  },
+  backText: {
+    fontSize: 16,
+    color: '#007AFF',
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 17,
+    fontWeight: '600',
+    color: '#000',
+    textAlign: 'center',
+  },
+  headerSpacer: {
+    width: 60,
+  },
+  content: {
+    flex: 1,
+    padding: 16,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#6B6B6B',
+    marginBottom: 24,
+    lineHeight: 20,
+  },
+  categoriesSection: {
+    marginBottom: 24,
+  },
+  categoryRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#e0e0e0',
+    marginBottom: 8,
+    backgroundColor: '#fff',
+  },
+  categoryRowSelected: {
+    borderColor: '#007AFF',
+    backgroundColor: '#F0F7FF',
+  },
+  categoryLabel: {
+    fontSize: 16,
+    color: '#000',
+  },
+  categoryLabelSelected: {
+    color: '#007AFF',
+    fontWeight: '500',
+  },
+  checkmark: {
+    fontSize: 16,
+    color: '#007AFF',
+    fontWeight: '600',
+  },
+  notesLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#333',
+    marginBottom: 8,
+  },
+  notesInput: {
+    borderWidth: 1,
+    borderColor: '#e0e0e0',
+    borderRadius: 10,
+    padding: 12,
+    fontSize: 15,
+    minHeight: 100,
+    color: '#000',
+  },
+  charCount: {
+    fontSize: 12,
+    color: '#999',
+    textAlign: 'right',
+    marginTop: 4,
+  },
+  errorText: {
+    fontSize: 14,
+    color: '#FF3B30',
+    marginTop: 12,
+  },
+  footer: {
+    padding: 16,
+    borderTopWidth: 1,
+    borderTopColor: '#e0e0e0',
+  },
+  submitButton: {
+    backgroundColor: '#007AFF',
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  submitButtonDisabled: {
+    backgroundColor: '#B0B0B0',
+  },
+  submitButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#fff',
+  },
+});

--- a/src/features/shares/types/chat.ts
+++ b/src/features/shares/types/chat.ts
@@ -1,5 +1,17 @@
 import { User } from "../../../types/auth";
 
+export enum ReportCategory {
+  Spam = 1,
+  Harassment = 2,
+  InappropriateContent = 3,
+  Other = 4,
+}
+
+export interface ReportMessageRequest {
+  category: ReportCategory;
+  notes?: string;
+}
+
 export interface ChatMessage {
   id: number;
   content: string;
@@ -7,6 +19,7 @@ export interface ChatMessage {
   senderName: string;
   shareId: number;
   sentAt: string;
+  isSystemMessage: boolean;
 }
 
 export interface SendMessageRequest {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -93,6 +93,21 @@ export const api = {
     return text ? JSON.parse(text) : null;
   },
 
+  postNoContent: async (endpoint: string, data: any) => {
+    const authHeaders = await getAuthHeaders();
+    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeaders,
+      },
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) {
+      throw new ApiError(response.status, `API Error: ${response.status}`);
+    }
+  },
+
   delete: async (endpoint: string, data?: any) => {
     const authHeaders = await getAuthHeaders();
     const response = await fetch(`${API_BASE_URL}${endpoint}`, {


### PR DESCRIPTION
Closes #120

## Summary
- Long-pressing another user's message opens a bottom sheet with a "Report Message" option
- Tapping "Report Message" navigates to a full-screen form with four categories (Spam, Harassment, Inappropriate Content, Other) and an optional notes field
- 409 "already reported" responses dismiss the screen with an informational toast rather than showing an inline error
- System messages are exempt from reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)