### PR TITLE
feat(notifications): show admin warning modal

### DIFF
--- a/src/components/TabNavigator.tsx
+++ b/src/components/TabNavigator.tsx
@@ -7,15 +7,19 @@ import { LibraryStack } from '../features/library/LibraryStack';
 import { SharesStack } from '../features/shares/SharesStack';
 import { CommunitiesStack } from '../features/communities/CommunitiesStack';
 import SettingsScreen from '../features/settings/SettingsScreen';
-import { useShareUnreadCount } from '../features/notifications/hooks/useNotifications';
+import { useShareUnreadCount, useAdminWarnings } from '../features/notifications/hooks/useNotifications';
+import { AdminWarningModal } from '../features/notifications/components/AdminWarningModal';
 
 const Tab = createBottomTabNavigator();
 
 export default function TabNavigator() {
   const unreadCount = useShareUnreadCount();
+  const adminWarnings = useAdminWarnings();
 
   return (
-    <Tab.Navigator
+    <>
+      {adminWarnings.length > 0 && <AdminWarningModal warnings={adminWarnings} />}
+      <Tab.Navigator
         screenOptions={({ route }) => ({
           tabBarIcon: ({ focused, color, size }) => {
             let iconName: any;
@@ -59,5 +63,6 @@ export default function TabNavigator() {
         <Tab.Screen name="Communities" component={CommunitiesStack} />
         <Tab.Screen name="Settings" component={SettingsScreen} />
       </Tab.Navigator>
+    </>
   );
 }

--- a/src/features/notifications/api/notificationsApi.ts
+++ b/src/features/notifications/api/notificationsApi.ts
@@ -16,4 +16,9 @@ export const notificationsApi = {
   markShareChatNotificationsRead: async (shareId: number): Promise<void> => {
     return api.patch(`/notifications/shares/${shareId}/chat/read`, {});
   },
+
+  // Mark a single notification as read by ID
+  markNotificationRead: async (notificationId: number): Promise<void> => {
+    return api.patch(`/notifications/${notificationId}/read`, {});
+  },
 };

--- a/src/features/notifications/components/AdminWarningModal.tsx
+++ b/src/features/notifications/components/AdminWarningModal.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+import { Modal, View, Text, TouchableOpacity, ActivityIndicator, StyleSheet } from 'react-native';
+import { Notification } from '../types';
+import { useMarkNotificationRead } from '../hooks/useNotifications';
+
+interface AdminWarningModalProps {
+  warnings: Notification[];
+}
+
+export function AdminWarningModal({ warnings }: AdminWarningModalProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const markRead = useMarkNotificationRead();
+
+  // Clamp index so external cache updates never leave us out of bounds
+  const safeIndex = Math.min(currentIndex, warnings.length - 1);
+  const currentWarning = warnings[safeIndex];
+
+  if (!currentWarning) {
+    return null;
+  }
+
+  const handleAcknowledge = () => {
+    markRead.mutate(currentWarning.id, {
+      onSuccess: () => {
+        setCurrentIndex((prev) => prev + 1);
+      },
+    });
+  };
+
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={() => {}}>
+      <TouchableOpacity
+        style={styles.overlay}
+        activeOpacity={1}
+        onPress={() => {}}
+      >
+        <View style={styles.card}>
+          <Text style={styles.header}>Warning from Admin</Text>
+          <Text style={styles.message}>{currentWarning.message.replace(/\\n/g, '\n')}</Text>
+          {warnings.length > 1 && (
+            <Text style={styles.counter}>
+              {safeIndex + 1} of {warnings.length}
+            </Text>
+          )}
+          {markRead.isError && (
+            <Text style={styles.errorText}>Failed to dismiss — please try again.</Text>
+          )}
+          <TouchableOpacity
+            style={[styles.button, markRead.isPending && styles.buttonPending]}
+            onPress={handleAcknowledge}
+            disabled={markRead.isPending}
+          >
+            {markRead.isPending ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.buttonText}>I Understand</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </TouchableOpacity>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 24,
+    width: '100%',
+    maxWidth: 400,
+    gap: 16,
+  },
+  header: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#D9000D',
+  },
+  message: {
+    fontSize: 16,
+    color: '#1C1C1E',
+    lineHeight: 24,
+  },
+  counter: {
+    fontSize: 13,
+    color: '#8E8E93',
+    textAlign: 'right',
+  },
+  errorText: {
+    fontSize: 13,
+    color: '#D9000D',
+  },
+  button: {
+    backgroundColor: '#007AFF',
+    borderRadius: 8,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  buttonPending: {
+    opacity: 0.7,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/src/features/notifications/hooks/useNotifications.ts
+++ b/src/features/notifications/hooks/useNotifications.ts
@@ -136,6 +136,51 @@ export function useMarkShareNotificationsRead(shareId: number) {
 }
 
 /**
+ * Derives unread AdminWarning notifications from the notifications cache
+ */
+export function useAdminWarnings() {
+  const { data: notifications = [] } = useNotifications();
+
+  return notifications.filter(
+    (notification) => notification.notificationType === NotificationTypes.ADMIN_WARNING
+  );
+}
+
+/**
+ * Mutation to mark a single notification as read by ID with optimistic update.
+ * Pass the notificationId to mutate(), not the hook — keeps the hook instance stable.
+ */
+export function useMarkNotificationRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (notificationId: number) => notificationsApi.markNotificationRead(notificationId),
+
+    onMutate: async (notificationId) => {
+      await queryClient.cancelQueries({ queryKey: NOTIFICATIONS_QUERY_KEY });
+
+      const previousNotifications = queryClient.getQueryData<Notification[]>(NOTIFICATIONS_QUERY_KEY);
+
+      queryClient.setQueryData<Notification[]>(NOTIFICATIONS_QUERY_KEY, (old = []) =>
+        old.filter((notification) => notification.id !== notificationId)
+      );
+
+      return { previousNotifications };
+    },
+
+    onError: (_err, _variables, context) => {
+      if (context?.previousNotifications) {
+        queryClient.setQueryData(NOTIFICATIONS_QUERY_KEY, context.previousNotifications);
+      }
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: NOTIFICATIONS_QUERY_KEY });
+    },
+  });
+}
+
+/**
  * Mutation to mark chat notifications as read with optimistic updates
  */
 export function useMarkChatNotificationsRead(shareId: number) {

--- a/src/features/notifications/types/index.ts
+++ b/src/features/notifications/types/index.ts
@@ -16,4 +16,5 @@ export const NotificationTypes = {
   DUE_DATE_CHANGED: 'ShareDueDateChanged',
   SHARE_MESSAGE_RECEIVED: 'ShareMessageReceived',
   USER_BOOK_WITHDRAWN: 'UserBookWithdrawn',
+  ADMIN_WARNING: 'AdminWarning',
 } as const;


### PR DESCRIPTION
Closes #122

## Summary
- Adds `AdminWarning` notification type and `PATCH /notifications/{id}/read` API call
- New `useAdminWarnings` hook derives unread admin warnings from the existing notifications cache
- New `useMarkNotificationRead` mutation accepts the ID via `mutate()` to keep the hook instance stable
- `AdminWarningModal` sequences through warnings one at a time — user must tap "I Understand" to advance; modal blocks all interaction behind it and suppresses Android back button
- Wired into `TabNavigator` so warnings surface immediately after login and on any subsequent poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)