### PR TITLE
feat(shares): add reputation indicator to share details screen

### DIFF
--- a/src/features/shares/ShareDetailsScreen.tsx
+++ b/src/features/shares/ShareDetailsScreen.tsx
@@ -25,6 +25,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { SharesStackParamList } from './SharesStack';
 import ShareStatusTimeline from './components/ShareStatusTimeline';
 import { sharesApi } from './api/sharesApi';
+import { useUserReputation } from './hooks/useUserReputation';
 import {
   useShareNotifications,
   useMarkShareNotificationsRead,
@@ -71,6 +72,24 @@ export default function ShareDetailsScreen() {
   // Determine if current user is the owner or borrower
   const isOwner = user?.id === ownerId;
   const isBorrower = user?.id === currentShare.borrower;
+
+  const otherPartyId = isOwner ? currentShare.borrower : ownerId;
+  const otherPartyRole: 'borrower' | 'lender' = isOwner ? 'borrower' : 'lender';
+  const { reputation } = useUserReputation(otherPartyId, otherPartyRole);
+
+  const formatReputation = (role: 'borrower' | 'lender'): string | null => {
+    if (!reputation) return null;
+    const { completedCount, disputeCount } = reputation;
+    const roleNoun = role === 'borrower' ? 'borrow' : 'lend';
+    const disputeLabel = disputeCount === 1 ? '1 dispute' : `${disputeCount} disputes`;
+    if (completedCount === 0 && disputeCount === 0) {
+      return `New member · 0 disputes`;
+    }
+    const completedLabel = completedCount === 1
+      ? `1 completed ${roleNoun}`
+      : `${completedCount} completed ${roleNoun}s`;
+    return `${completedLabel} · ${disputeLabel}`;
+  };
 
   // Mark share notifications as read after a delay (gives user time to see the animation)
   useEffect(() => {
@@ -317,16 +336,26 @@ export default function ShareDetailsScreen() {
 
           <View style={styles.detailsGroup}>
             {isBorrower && (
-              <Text style={styles.detailText}>
-                <Text style={styles.detailLabel}>Owner: </Text>
-                {owner.firstName} {owner.lastName}
-              </Text>
+              <>
+                <Text style={styles.detailText}>
+                  <Text style={styles.detailLabel}>Owner: </Text>
+                  {owner.firstName} {owner.lastName}
+                </Text>
+                {formatReputation('lender') !== null && (
+                  <Text style={styles.reputationText}>{formatReputation('lender')}</Text>
+                )}
+              </>
             )}
             {isOwner && (
-              <Text style={styles.detailText}>
-                <Text style={styles.detailLabel}>Borrower: </Text>
-                {borrowerUser.firstName} {borrowerUser.lastName}
-              </Text>
+              <>
+                <Text style={styles.detailText}>
+                  <Text style={styles.detailLabel}>Borrower: </Text>
+                  {borrowerUser.firstName} {borrowerUser.lastName}
+                </Text>
+                {formatReputation('borrower') !== null && (
+                  <Text style={styles.reputationText}>{formatReputation('borrower')}</Text>
+                )}
+              </>
             )}
             <View
               style={[
@@ -578,6 +607,10 @@ const styles = StyleSheet.create({
   },
   detailLabel: {
     fontWeight: '600',
+  },
+  reputationText: {
+    fontSize: 12,
+    color: '#8E8E93',
   },
   // No padding in default state to align with "Owner"/"Borrower" labels and maintain
   // consistent 4px vertical spacing. Padding only applied in highlighted state where

--- a/src/features/shares/api/reputationApi.ts
+++ b/src/features/shares/api/reputationApi.ts
@@ -1,0 +1,7 @@
+import { api } from '../../../lib/api';
+import { UserReputation } from '../types';
+
+export const reputationApi = {
+  getReputationStats: async (userId: string, role: 'borrower' | 'lender'): Promise<UserReputation> =>
+    api.get(`/users/${userId}/reputation?role=${role}`),
+};

--- a/src/features/shares/hooks/useUserReputation.ts
+++ b/src/features/shares/hooks/useUserReputation.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect, useCallback } from 'react';
+import { UserReputation } from '../types';
+import { reputationApi } from '../api/reputationApi';
+
+export const useUserReputation = (userId: string, role: 'borrower' | 'lender') => {
+  const [reputation, setReputation] = useState<UserReputation | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchReputation = useCallback(async () => {
+    if (!userId) return;
+    setLoading(true);
+    try {
+      const data = await reputationApi.getReputationStats(userId, role);
+      setReputation(data);
+    } catch (err) {
+      console.error('Failed to fetch user reputation:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId, role]);
+
+  useEffect(() => {
+    fetchReputation();
+  }, [fetchReputation]);
+
+  return { reputation, loading };
+};

--- a/src/features/shares/types/index.ts
+++ b/src/features/shares/types/index.ts
@@ -21,3 +21,8 @@ export interface Share {
   userBook: UserBookWithOwner;
   borrowerUser: User;
 }
+
+export interface UserReputation {
+  completedCount: number;
+  disputeCount: number;
+}


### PR DESCRIPTION
Closes #126

## Summary

- Adds a compact reputation line beneath the other party's name on the Share Details screen
- Lenders see the borrower's completed borrow count and dispute count; borrowers see the lender's completed lend count and dispute count
- Users with no history in a role are labelled "New member · 0 disputes" rather than showing a zero count
- Fetches stats automatically on screen load via the existing `GET /users/{userId}/reputation?role=` endpoint — no backend changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)